### PR TITLE
Update DGGeofencing.m

### DIFF
--- a/src/ios/src/DGGeofencing.m
+++ b/src/ios/src/DGGeofencing.m
@@ -349,7 +349,7 @@
     
     if (![self isAuthorized])
     {
-        NSString* message = nil;
+        NSString* message = @"User has explicitly denied authorization for this application, or location services are disabled in Settings.";
         BOOL authStatusAvailable = [CLLocationManager respondsToSelector:@selector(authorizationStatus)]; // iOS 4.2+
         if (authStatusAvailable) {
             NSUInteger code = [CLLocationManager authorizationStatus];


### PR DESCRIPTION
The current code "message = nil" causes app to crash on iOS8 if background services is set to "never."