### PR TITLE
Remove unnecessary Android permissions from plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,7 +55,6 @@
 			<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 			<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 			<uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
-			<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 			<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 			<uses-permission android:name="android.permission.GET_ACCOUNTS" />
 			<uses-permission android:name="android.permission.BROADCAST_STICKY" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,17 +52,9 @@
 		</config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
-			<uses-permission android:name="android.permission.CAMERA" />
-			<uses-permission android:name="android.permission.VIBRATE" />
 			<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 			<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 			<uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
-			<uses-permission android:name="android.permission.RECEIVE_SMS" />
-			<uses-permission android:name="android.permission.RECORD_AUDIO" />
-			<uses-permission android:name="android.permission.RECORD_VIDEO" />
-			<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-			<uses-permission android:name="android.permission.READ_CONTACTS" />
-			<uses-permission android:name="android.permission.WRITE_CONTACTS" />
 			<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 			<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 			<uses-permission android:name="android.permission.GET_ACCOUNTS" />


### PR DESCRIPTION
Hi,

This pull request removes unnecessary Android permissions from plugin.xml.  I am assuming that the geofencing plugin doesn't need access to e.g. the camera.